### PR TITLE
Remove maintainers mistakenly added

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,5 +39,3 @@ extra:
   recipe-maintainers:
     - ericdill
     - janschulz
-    - licode
-    - tacaswell


### PR DESCRIPTION
My mistake here too @janschulz . Turns out this is no longer part of our stack. (Used to be which is why I had a recipe for it and thus why I thought it _was_ still part of our stack). Sorry for the noise...
